### PR TITLE
Adding before_filter to exchange controller actions

### DIFF
--- a/app/controllers/exchanges_controller.rb
+++ b/app/controllers/exchanges_controller.rb
@@ -1,4 +1,6 @@
 class ExchangesController < ApplicationController
+  before_action :ensure_logged_in, only: [:new, :create]
+
   def new
     @match = Match.includes(pool: :tournament).find_by_id(params[:match_id])
     @exchange = @match.exchanges.new


### PR DESCRIPTION
Ensuring only logged-in users can create exchanges.
