### PR TITLE
Fixing exchanges and match_info

### DIFF
--- a/app/models/exchange.rb
+++ b/app/models/exchange.rb
@@ -5,30 +5,25 @@
 #  id         :integer          not null, primary key
 #  match_id   :integer          not null
 #  target     :string(255)
-#  afterblow  :boolean          not null
-#  double_hit :boolean          not null
+#  afterblow  :boolean          default(FALSE)
+#  double_hit :boolean          default(FALSE)
 #  penalty    :integer
 #  fighter_id :integer          not null
-#  seconds    :integer          not null
-#  points     :integer
 #  created_at :datetime
 #  updated_at :datetime
+#  seconds    :integer          not null
+#  points     :integer
 #
 
 class Exchange < ActiveRecord::Base
-  validates :match_id, :fighter_id, :afterblow, :double_hit, :seconds, presence: true
-  belongs_to :match
+  validates :match_id, :fighter_id, :seconds, presence: true
+  belongs_to :match, dependent: :destroy
 
-  before_create :fill_boolean_fields, :add_points
-  before_save :fill_boolean_fields, :add_points
-
-  def fill_boolean_fields
-    self.afterblow ||= 'false'
-    self.double_hit ||= 'false'
-  end
+  before_create :add_points
+  before_save :add_points
 
   def add_points
     scores = match.pool.tournament.scores
-    points = scores.where(target: target).first.points
+    self.points = scores.where(target: target).first.points
   end
 end

--- a/app/models/match.rb
+++ b/app/models/match.rb
@@ -41,15 +41,25 @@ class Match < ActiveRecord::Base
   end
 
   def update_match_info
-    max_points = pool.tournament.victory_points
-    max_seconds = pool.tournament.duration
     fighter_scores = Hash.new { |hash, key| hash[key] = 0 }
 
     exchanges.each do |exchange|
       fighter_scores[exchange.fighter_id] += exchange.points
     end
 
-    if fighter_scores.values.any? { |points| points >= max_points }
+    update_match_completed(fighter_scores)
+  end
+
+  def update_match_completed(fighter_scores)
+    max_seconds = pool.tournament.duration
+    max_points = pool.tournament.victory_points
+    points = fighter_scores.values
+
+    if max_points && points.any? { |points| points >= max_points }
+      match_info.update(match_completed: true)
+    end
+
+    if max_seconds && elapsed_time >= max_seconds && points.first != points.last
       match_info.update(match_completed: true)
     end
   end

--- a/app/models/pool.rb
+++ b/app/models/pool.rb
@@ -11,7 +11,7 @@
 
 class Pool < ActiveRecord::Base
   validates :tournament_id, :name, presence: true
-  belongs_to :tournament
+  belongs_to :tournament, dependent: :destroy
   has_many :matches
   has_many :pool_fighters,
     class_name: 'PoolFighter',

--- a/app/models/score.rb
+++ b/app/models/score.rb
@@ -12,5 +12,6 @@
 
 class Score < ActiveRecord::Base
   validates :tournament_id, :target, :points, presence: true
+  validates_uniqueness_of :target, scope: :tournament_id
   belongs_to :tournament, dependent: :destroy
 end

--- a/db/migrate/20150819053146_exchanges_allow_afterblow_null.rb
+++ b/db/migrate/20150819053146_exchanges_allow_afterblow_null.rb
@@ -1,0 +1,6 @@
+class ExchangesAllowAfterblowNull < ActiveRecord::Migration
+  def change
+    change_column :exchanges, :afterblow, :boolean, null: true, default: false
+    change_column :exchanges, :double_hit, :boolean, null: true, default: false
+  end
+end

--- a/db/migrate/20150819063550_scores_target_tournament_dual_index.rb
+++ b/db/migrate/20150819063550_scores_target_tournament_dual_index.rb
@@ -1,0 +1,5 @@
+class ScoresTargetTournamentDualIndex < ActiveRecord::Migration
+  def change
+    add_index :scores, [:target, :tournament_id], unique: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20150818040910) do
+ActiveRecord::Schema.define(version: 20150819063550) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -30,15 +30,15 @@ ActiveRecord::Schema.define(version: 20150818040910) do
   add_index "events", ["organizer"], name: "index_events_on_organizer", using: :btree
 
   create_table "exchanges", force: true do |t|
-    t.integer  "match_id",   null: false
+    t.integer  "match_id",                   null: false
     t.string   "target"
-    t.boolean  "afterblow",  null: false
-    t.boolean  "double_hit", null: false
+    t.boolean  "afterblow",  default: false
+    t.boolean  "double_hit", default: false
     t.integer  "penalty"
-    t.integer  "fighter_id", null: false
+    t.integer  "fighter_id",                 null: false
     t.datetime "created_at"
     t.datetime "updated_at"
-    t.integer  "seconds",    null: false
+    t.integer  "seconds",                    null: false
     t.integer  "points"
   end
 
@@ -115,6 +115,7 @@ ActiveRecord::Schema.define(version: 20150818040910) do
     t.datetime "updated_at"
   end
 
+  add_index "scores", ["target", "tournament_id"], name: "index_scores_on_target_and_tournament_id", unique: true, using: :btree
   add_index "scores", ["tournament_id"], name: "index_scores_on_tournament_id", using: :btree
 
   create_table "tournaments", force: true do |t|

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -11,8 +11,8 @@ EVENTS = [
 ]
 
 TOURNAMENTS = [
-  { name: 'Longsword Test', weapon_type: 'steel' },
-  { name: 'Rapier Test', weapon_type: 'steel' }
+  { name: 'Longsword Test', weapon_type: 'steel', victory_points: 15 },
+  { name: 'Rapier Test', weapon_type: 'steel', duration: 120 }
 ]
 
 SCORES = [

--- a/spec/models/exchange_spec.rb
+++ b/spec/models/exchange_spec.rb
@@ -5,8 +5,8 @@
 #  id         :integer          not null, primary key
 #  match_id   :integer          not null
 #  target     :string(255)
-#  afterblow  :boolean          not null
-#  double_hit :boolean          not null
+#  afterblow  :boolean          default(FALSE)
+#  double_hit :boolean          default(FALSE)
 #  penalty    :integer
 #  fighter_id :integer          not null
 #  created_at :datetime


### PR DESCRIPTION
- Allowing `afterblow` and `double_hit` to be blank
- Checking for `tournament.victory_points` before completion
- Checking for `tournament.duration` before completion
- Disallowing same target scoring rule (meaning you can't have `arm` and `arm` in score rules for the same tournament)
